### PR TITLE
Fix the issue of multi line escape symbols for obtaining variable values in uci

### DIFF
--- a/root/usr/share/AdGuardHome/update_core.sh
+++ b/root/usr/share/AdGuardHome/update_core.sh
@@ -124,7 +124,7 @@ doupdate_core(){
 		EXIT 1
 	fi
 	echo "$downloadlinks" | grep -v "^#" >/tmp/AdG_links.txt
-	while read link
+	while IFS= read -r link
 	do
 		[ -n "$link" ] || continue
 		link="${link//\$\{latest_ver\}/$latest_ver}"


### PR DESCRIPTION
内核下载链接的结尾 \ 符号会导致后续内核压缩包 gz 结尾判断错误，导致无法正确的解压内核压缩包。