### PR TITLE
Fix query log cleanup when backup storage is full

### DIFF
--- a/root/etc/init.d/AdGuardHome
+++ b/root/etc/init.d/AdGuardHome
@@ -314,13 +314,12 @@ backup() {
 		while :
 		do
 			if [ -d "$backupwdpath/data/$one" ]; then
-				cpret=$(cp -u -r -f $workdir/data/$one $backupwdpath/data 2>&1)
+				cpret=$(LC_ALL=C cp -u -r -f $workdir/data/$one $backupwdpath/data 2>&1)
 			else
-				cpret=$(cp -u -r -f $workdir/data/$one $backupwdpath/data/$one 2>&1)
+				cpret=$(LC_ALL=C cp -u -r -f $workdir/data/$one $backupwdpath/data/$one 2>&1)
 			fi
 			echo "$cpret"
-			echo "$cpret" | grep "no space left on device"
-			if [ "$?" == "0" ]; then
+			if printf '%s\n' "$cpret" | grep -qiF "no space left on device"; then
 				echo "Disk full, deleting log and retrying"
 				del_querylog && continue
 				rm -f -r $backupwdpath/data/filters
@@ -488,16 +487,16 @@ del_querylog(){
 	local wtarget=$(ls $workdir/data | grep -F "querylog.json" | sort -r | head -n 1)
 	if [ "$btarget"x == "$wtarget"x ]; then
 		[ -z "$btarget" ] && return 1
-		rm -f $workdir/data/$wtarget
-		rm -f $backupwdpath/data/$btarget
+		rm -f "$workdir/data/$wtarget" || return 1
+		rm -f "$backupwdpath/data/$btarget" || return 1
 		return 0
 	fi
 	if [ "$btarget" \> "$wtarget" ]; then
-		rm -f $backupwdpath/data/$btarget
-		return 0
+		rm -f "$backupwdpath/data/$btarget"
+		return $?
 	else
-		rm -f $workdir/data/$wtarget
-		return 0
+		rm -f "$workdir/data/$wtarget"
+		return $?
 	fi
 }
 stop_service()


### PR DESCRIPTION
## 修改内容

修复备份目录空间不足时无法自动删除查询日志的问题

修改 `root/etc/init.d/AdGuardHome`：

- 使用 `LC_ALL=C` 执行 `cp`，避免错误信息受系统语言影响
- 使用 `grep -qiF` 检测 `No space left on device`
- 为 `rm` 使用的文件路径添加双引号
- 删除日志失败时返回错误，不再继续重试备份

## 问题原因

原代码使用下面的命令检测磁盘空间不足：

```sh
grep "no space left on device"
```

但 `cp` 返回的错误信息为：

```text
No space left on device
```

`grep` 默认区分大小写，导致匹配失败，后续的 `del_querylog` 不会执行

另外，`del_querylog` 在 `rm` 执行失败时仍会返回成功，可能导致备份在没有释放空间的情况下重复执行